### PR TITLE
[BE] oauth 로그인 후 토큰 처리 수정

### DIFF
--- a/src/main/java/com/OmObe/OmO/auth/handler/OAuth2MemberSuccessHandler.java
+++ b/src/main/java/com/OmObe/OmO/auth/handler/OAuth2MemberSuccessHandler.java
@@ -63,7 +63,7 @@ public class OAuth2MemberSuccessHandler extends SimpleUrlAuthenticationSuccessHa
         String path = distinctionPath(member);
         log.info("path : {}", path);
 
-        String uri = createURI(path).toString(); // 리다이렉트할 url
+        String uri = createURI(path, accessToken, refreshToken).toString(); // 리다이렉트할 url
         getRedirectStrategy().sendRedirect(request, response, uri);
     }
 
@@ -95,8 +95,10 @@ public class OAuth2MemberSuccessHandler extends SimpleUrlAuthenticationSuccessHa
         }
     }
 
-    private URI createURI(String path) {
+    private URI createURI(String path, String accessToken, String refreshToken) {
         MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
+        queryParams.add("access_token", "Bearer " + accessToken);
+        queryParams.add("refresh_token", refreshToken);
 
         return UriComponentsBuilder
                 .newInstance()
@@ -107,7 +109,7 @@ public class OAuth2MemberSuccessHandler extends SimpleUrlAuthenticationSuccessHa
                 .port(5173)
 //                .port(8080)
                 .path(path)
-//                .queryParams(queryParams)
+                .queryParams(queryParams)
                 .build()
                 .toUri();
     }

--- a/src/main/java/com/OmObe/OmO/auth/oauth/controller/OAuthController.java
+++ b/src/main/java/com/OmObe/OmO/auth/oauth/controller/OAuthController.java
@@ -30,37 +30,37 @@ public class OAuthController {
     브라우저에서 oauth 로그인하는 출처에 직접 접근 시 CORS 문제 발생
     todo: 프론트엔드와 테스트 후 사용 여부 결정
      */
-    @GetMapping("/api/login/{oauth}")
-    public RedirectView oAuthLoginController(@PathVariable("oauth") String oauth) {
-        RedirectView redirectView = new RedirectView();
-
-        redirectView.setUrl("https://api.oneulmohae.co.kr/oauth2/authorization/" + oauth);
-        return redirectView;
-    }
+//    @GetMapping("/api/login/{oauth}")
+//    public RedirectView oAuthLoginController(@PathVariable("oauth") String oauth) {
+//        RedirectView redirectView = new RedirectView();
+//
+//        redirectView.setUrl("https://api.oneulmohae.co.kr/oauth2/authorization/" + oauth);
+//        return redirectView;
+//    }
 
     /*
     <OAuth2 로그인 성공 후 헤더에 access token, refresh token 설정>
     OAuth2 로그인을 통해 얻은 access token과 refresh token은 OAuth2를 제공하는 서비스 자원에 접근할 수 있는 토큰이다.
     해당 애플리케이션에 접근 가능한 권한을 주기 위해서는 헤더에 access token과 refresh token을 설정한다.
      */
-//    @GetMapping("/api/login/oauth")
-//    public ResponseEntity oAuthLoginSuccessController(HttpServletRequest request,
-//                                                      HttpServletResponse response,
-//                                                      @RequestParam("accessToken") String accessToken,
-//                                                      @RequestParam("refreshToken") String refreshToken) {
-//
-////        String token = accessToken.substring(7); // 액세스 토큰 추출
-////        Member member = memberService.jwtTokenToMember(token); // 토큰을 통해 인증된 member를 추출
-////        MemberDto.Response dto = mapper.memberToMemberResponseDto(member);
-//
-//        // access token, refresh token을 헤더에 설정
-//        response.setHeader("Authorization", "Bearer " + accessToken);
-//        response.setHeader("Refresh", refreshToken);
-//
-//        log.info("accessToken : {}", response.getHeader("Authorization"));
-//        log.info("refreshToken : {}", response.getHeader("Refresh"));
-//
-//        return new ResponseEntity(HttpStatus.OK);
-//
-//    }
+    @GetMapping("/api/login/oauth")
+    public ResponseEntity oAuthLoginSuccessController(HttpServletRequest request,
+                                                      HttpServletResponse response,
+                                                      @RequestParam("accessToken") String accessToken,
+                                                      @RequestParam("refreshToken") String refreshToken) {
+
+//        String token = accessToken.substring(7); // 액세스 토큰 추출
+//        Member member = memberService.jwtTokenToMember(token); // 토큰을 통해 인증된 member를 추출
+//        MemberDto.Response dto = mapper.memberToMemberResponseDto(member);
+
+        // access token, refresh token을 헤더에 설정
+        response.setHeader("Authorization", "Bearer " + accessToken);
+        response.setHeader("Refresh", refreshToken);
+
+        log.info("accessToken : {}", response.getHeader("Authorization"));
+        log.info("refreshToken : {}", response.getHeader("Refresh"));
+
+        return new ResponseEntity(HttpStatus.OK);
+
+    }
 }


### PR DESCRIPTION
- oauth 로그인 시 토큰을 쿼리 파라미터로 전달
- oauth 로그인 성공 후 토큰을 응답 헤더에 저장하는 컨트롤러 설정